### PR TITLE
Add Support for JMX control of the agent

### DIFF
--- a/core/org.openjdk.jmc.agent/pom.xml
+++ b/core/org.openjdk.jmc.agent/pom.xml
@@ -75,7 +75,7 @@
 							<Automatic-Module-Name>org.openjdk.jmc.agent</Automatic-Module-Name>
 							<Agent-Class>org.openjdk.jmc.agent.Agent</Agent-Class>
 							<Premain-Class>org.openjdk.jmc.agent.Agent</Premain-Class>
-							<Can-Retransform-Classes>org.openjdk.jmc.agent.Agent</Can-Retransform-Classes>
+							<Can-Retransform-Classes>true</Can-Retransform-Classes>
 							<Bundle-RequiredExecutionEnvironment>JavaSE-1.7</Bundle-RequiredExecutionEnvironment>
 							<Built-By></Built-By>
 						</manifestEntries>
@@ -89,6 +89,26 @@
 				<configuration>
 					<argLine> --add-opens java.base/jdk.internal.misc=ALL-UNNAMED
 						-XX:+FlightRecorder</argLine>
+					<excludes>TestRetransform.java</excludes>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-failsafe-plugin</artifactId>
+				<version>3.0.0-M3</version>
+				<executions>
+          			<execution>
+            			<goals>
+              				<goal>integration-test</goal>
+              				<goal>verify</goal>
+            			</goals>
+          			</execution>
+        		</executions>
+				<configuration>
+					<argLine> --add-opens java.base/jdk.internal.misc=ALL-UNNAMED
+						-XX:+FlightRecorder -javaagent:target/org.openjdk.jmc.agent-1.0.0-SNAPSHOT.jar=target/test-classes/org/openjdk/jmc/agent/test/jfrprobes_template.xml
+						 -cp target/org.openjdk.jmc.agent-1.0.0-SNAPSHOT.jar:target/test-classes/ </argLine>
+					<includes>TestRetransform.java</includes>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/core/org.openjdk.jmc.agent/src/main/java/org/openjdk/jmc/agent/Agent.java
+++ b/core/org.openjdk.jmc.agent/src/main/java/org/openjdk/jmc/agent/Agent.java
@@ -101,7 +101,7 @@ public class Agent {
 			throws XMLStreamException {
 		TransformRegistry registry = DefaultTransformRegistry.from(configuration);
 		instrumentationInstance = instrumentation;
-		instrumentation.addTransformer(new Transformer(registry));
+		instrumentation.addTransformer(new Transformer(registry), true);
 		AgentManagementFactory.createAndRegisterAgentControllerMBean(instrumentation, registry);
 	}
 

--- a/core/org.openjdk.jmc.agent/src/main/java/org/openjdk/jmc/agent/TransformRegistry.java
+++ b/core/org.openjdk.jmc.agent/src/main/java/org/openjdk/jmc/agent/TransformRegistry.java
@@ -34,6 +34,8 @@ package org.openjdk.jmc.agent;
 
 import java.util.List;
 
+import org.openjdk.jmc.agent.impl.DefaultTransformRegistry;
+
 public interface TransformRegistry {
 	/**
 	 * The named class has transforms that have not been executed yet.
@@ -54,12 +56,11 @@ public interface TransformRegistry {
 	List<TransformDescriptor> getTransformData(String className);
 
 	/**
-	 * Retransforms classes according to the xml description.
+	 * Updates the registry to reflect desired retransformation of classes according to the xml description.
 	 *
 	 * @param xmlDescription
 	 *            an XML snippet describing the wanted transformations.
-	 * @return a class array
+	 * @return a list of {@link TransformDescriptor}s corresponding to the wanted transformations.
 	 */
-	// FIXME: We should only update the transformation registry! The actual retransforms should happen elsewhere!
-	Class<?>[] update(String xmlDescription);
+	List<TransformDescriptor> update(String xmlDescription);
 }

--- a/core/org.openjdk.jmc.agent/src/main/java/org/openjdk/jmc/agent/jmx/AgentControllerMBean.java
+++ b/core/org.openjdk.jmc.agent/src/main/java/org/openjdk/jmc/agent/jmx/AgentControllerMBean.java
@@ -33,5 +33,5 @@
 package org.openjdk.jmc.agent.jmx;
 
 public interface AgentControllerMBean {
-	public void retransformClasses(String xmlDescription) throws Exception;
+	public Class<?>[] retransformClasses(String xmlDescription) throws Exception;
 }

--- a/core/org.openjdk.jmc.agent/src/test/java/org/openjdk/jmc/agent/test/TestDefaultTransformRegistry.java
+++ b/core/org.openjdk.jmc.agent/src/test/java/org/openjdk/jmc/agent/test/TestDefaultTransformRegistry.java
@@ -32,6 +32,7 @@
  */
 package org.openjdk.jmc.agent.test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -48,6 +49,23 @@ import org.openjdk.jmc.agent.impl.DefaultTransformRegistry;
 import org.openjdk.jmc.agent.test.util.TestToolkit;
 
 public class TestDefaultTransformRegistry {
+	
+	private static final String XML_DESCRIPTION = "<jfragent>"
+			+ "<events>"
+			+ "<event id=\"testing.jfr.testI1\">"
+			+ "<name>Test For Retransform and Update</name>"
+			+ "<description>This is a test event.</description>"
+			+ "<path>demo/retransformEvent1</path>"
+			+ "<stacktrace>false</stacktrace>"
+			+ "<class>org.openjdk.jmc.agent.test.TestRetransform</class>"
+			+ "<method>"
+			+ "<name>test</name>"
+			+ "<descriptor>()V</descriptor>"
+			+ "</method>"
+			+ "<location>WRAP</location>"
+			+ "</event>"
+			+ "</events>"
+			+ "</jfragent>"; 
 	
 	public static String getTemplate() throws IOException {
 		return TestToolkit.readTemplate(TestDefaultTransformRegistry.class, TestToolkit.DEFAULT_TEMPLATE_NAME);
@@ -76,5 +94,17 @@ public class TestDefaultTransformRegistry {
 		List<TransformDescriptor> transformData = registry.getTransformData(Type.getInternalName(InstrumentMe.class));
 		assertNotNull(transformData);
 		assertTrue(transformData.size() > 0);
+	}
+	
+	@Test
+	public void testUpdate() throws XMLStreamException, IOException {
+		TransformRegistry registry = DefaultTransformRegistry
+				.from(TestToolkit.getProbesXMLFromTemplate(getTemplate(), "From")); //$NON-NLS-1$
+		assertNotNull(registry);
+		List<TransformDescriptor> descriptors = registry.update(XML_DESCRIPTION);
+		assertNotNull(descriptors);
+		assertEquals(descriptors.get(0).getClassName(), "org/openjdk/jmc/agent/test/TestRetransform");
+		assertEquals(descriptors.get(0).getMethod().toString(), "test()V");
+		assertTrue(registry.hasPendingTransforms("org/openjdk/jmc/agent/test/TestRetransform"));
 	}
 }

--- a/core/org.openjdk.jmc.agent/src/test/java/org/openjdk/jmc/agent/test/TestRetransform.java
+++ b/core/org.openjdk.jmc.agent/src/test/java/org/openjdk/jmc/agent/test/TestRetransform.java
@@ -1,0 +1,76 @@
+package org.openjdk.jmc.agent.test;
+
+import static org.junit.Assert.assertNotNull;
+
+import java.io.PrintWriter;
+import java.lang.management.ManagementFactory;
+import java.util.logging.Level;
+
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+
+import org.junit.Test;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.util.CheckClassAdapter;
+import org.objectweb.asm.util.TraceClassVisitor;
+import org.openjdk.jmc.agent.Agent;
+import org.openjdk.jmc.agent.test.util.TestToolkit;
+
+public class TestRetransform {
+	
+	/**
+	 * Goals/Questions for TestRetransform
+	 * 
+	 * - How can we get the agent instance to test with?
+	 * -- Where can we get instrumentation from for testing
+	 * - Can we delay this test until the jar is built?
+	 * - We need to open up jdk.attach for this on jdk11
+	 */
+
+	private static final String AGENT_OBJECT_NAME = "org.openjdk.jmc.jfr.agent:type=AgentController"; //$NON-NLS-1$
+	private static final String TEST_CLASS = "org.openjdk.jmc.agent.test.TestRetransform";
+	
+	/**
+	 * XML Description to check that we're parsing XML snippets into
+	 * transform descriptors correctly
+	 */
+	private static final String XML_DESCRIPTION = "<jfragent>"
+			+ "<events>"
+			+ "<event id=\"testing.jfr.testI1\">"
+			+ "<name>Test For Retransform and Update</name>"
+			+ "<description>This is a test event.</description>"
+			+ "<path>demo/retransformEvent1</path>"
+			+ "<stacktrace>false</stacktrace>"
+			+ "<class>org.openjdk.jmc.agent.test.TestRetransform</class>"
+			+ "<method>"
+			+ "<name>test</name>"
+			+ "<descriptor>()V</descriptor>"
+			+ "</method>"
+			+ "<location>WRAP</location>"
+			+ "</event>"
+			+ "</events>"
+			+ "</jfragent>"; 
+
+	@Test
+	public void testRetransform() throws Exception {
+		// Invoke retransform
+		MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
+		ObjectName name = new ObjectName(AGENT_OBJECT_NAME);
+		Object[] parameters = {XML_DESCRIPTION};
+		String[] signature = {String.class.getName()};
+		Class<?>[] clazzes = (Class<?>[]) mbs.invoke(name, "retransformClasses", parameters, signature);
+		assertNotNull(clazzes);
+		if (Agent.getLogger().isLoggable(Level.FINE)) {
+			for (Class<?> clazz : clazzes) {
+				// If we've asked for verbose information, we write the generated class
+				TraceClassVisitor visitor = new TraceClassVisitor(new PrintWriter(System.out));
+				CheckClassAdapter checkAdapter = new CheckClassAdapter(visitor);
+				ClassReader reader = new ClassReader(TestToolkit.getByteCode(clazz));
+			}
+		}
+	}
+	
+	public void test() {
+		//Dummy method for instrumentation
+	}
+}

--- a/core/org.openjdk.jmc.agent/src/test/java/org/openjdk/jmc/agent/test/TestRetransform.java
+++ b/core/org.openjdk.jmc.agent/src/test/java/org/openjdk/jmc/agent/test/TestRetransform.java
@@ -1,3 +1,36 @@
+/*
+ * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Red Hat Inc. All rights reserved.
+ * 
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The contents of this file are subject to the terms of either the Universal Permissive License
+ * v 1.0 as shown at http://oss.oracle.com/licenses/upl
+ *
+ * or the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted
+ * provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
+ * and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided with
+ * the distribution.
+ * 
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package org.openjdk.jmc.agent.test;
 
 import static org.junit.Assert.assertNotNull;
@@ -17,23 +50,10 @@ import org.openjdk.jmc.agent.Agent;
 import org.openjdk.jmc.agent.test.util.TestToolkit;
 
 public class TestRetransform {
-	
-	/**
-	 * Goals/Questions for TestRetransform
-	 * 
-	 * - How can we get the agent instance to test with?
-	 * -- Where can we get instrumentation from for testing
-	 * - Can we delay this test until the jar is built?
-	 * - We need to open up jdk.attach for this on jdk11
-	 */
 
 	private static final String AGENT_OBJECT_NAME = "org.openjdk.jmc.jfr.agent:type=AgentController"; //$NON-NLS-1$
 	private static final String TEST_CLASS = "org.openjdk.jmc.agent.test.TestRetransform";
 	
-	/**
-	 * XML Description to check that we're parsing XML snippets into
-	 * transform descriptors correctly
-	 */
 	private static final String XML_DESCRIPTION = "<jfragent>"
 			+ "<events>"
 			+ "<event id=\"testing.jfr.testI1\">"


### PR DESCRIPTION
Hi Marcus,

The following patch adds support for controlling the agent over JMX. In particular it adds an implementation of update() in defaultTransformationRegistry and an implementation of retransformClasses() in AgentController.

This allows users to make invoke retransformClasses via the AgentControllerMBean.

Have a look and let me know what you think.

Cheers,

- Josh