### PR TITLE
JMC-6532: Instrumentation fails for methods containing try-catch clauses

### DIFF
--- a/core/org.openjdk.jmc.agent/src/main/java/org/openjdk/jmc/agent/jfr/impl/JFRMethodAdvisor.java
+++ b/core/org.openjdk.jmc.agent/src/main/java/org/openjdk/jmc/agent/jfr/impl/JFRMethodAdvisor.java
@@ -33,6 +33,7 @@
 package org.openjdk.jmc.agent.jfr.impl;
 
 import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.commons.AdviceAdapter;
 import org.openjdk.jmc.agent.Parameter;
@@ -125,4 +126,10 @@ public class JFRMethodAdvisor extends AdviceAdapter {
 		mv.visitMethodInsn(INVOKEVIRTUAL, transformDescriptor.getEventClassName(), "end", "()V", false); //$NON-NLS-1$ //$NON-NLS-2$
 		mv.visitMethodInsn(INVOKEVIRTUAL, transformDescriptor.getEventClassName(), "commit", "()V", false); //$NON-NLS-1$ //$NON-NLS-2$
 	}
+
+    @Override
+    public void visitFrame(int type, int numLocal, Object[] local, int numStack, Object[] stack) {
+        // force to always use expanded frames
+        super.visitFrame(Opcodes.F_NEW, numLocal, local, numStack, stack);
+    }
 }

--- a/core/org.openjdk.jmc.agent/src/main/java/org/openjdk/jmc/agent/jfrnext/impl/JFRNextMethodAdvisor.java
+++ b/core/org.openjdk.jmc.agent/src/main/java/org/openjdk/jmc/agent/jfrnext/impl/JFRNextMethodAdvisor.java
@@ -33,6 +33,7 @@
 package org.openjdk.jmc.agent.jfrnext.impl;
 
 import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.commons.AdviceAdapter;
 import org.openjdk.jmc.agent.Parameter;
@@ -121,5 +122,11 @@ public class JFRNextMethodAdvisor extends AdviceAdapter {
 	private void commitEvent() {
 		mv.visitVarInsn(ALOAD, eventLocal);
 		mv.visitMethodInsn(INVOKEVIRTUAL, transformDescriptor.getEventClassName(), "commit", "()V", false); //$NON-NLS-1$ //$NON-NLS-2$
+	}
+
+	@Override
+	public void visitFrame(int type, int numLocal, Object[] local, int numStack, Object[] stack) {
+		// force to always use expanded frames
+		super.visitFrame(Opcodes.F_NEW, numLocal, local, numStack, stack);
 	}
 }

--- a/core/org.openjdk.jmc.agent/src/test/java/org/openjdk/jmc/agent/test/InstrumentMe.java
+++ b/core/org.openjdk.jmc.agent/src/test/java/org/openjdk/jmc/agent/test/InstrumentMe.java
@@ -64,6 +64,7 @@ public class InstrumentMe {
 	}
 
 	private static void runInstance(InstrumentMe instance) throws InterruptedException {
+		System.out.println("Running instance versions..."); //$NON-NLS-1$
 		instance.printInstanceHelloWorld1();
 		instance.printInstanceHelloWorld2(TestToolkit.randomString(), TestToolkit.randomLong());
 		instance.printInstanceHelloWorld3(Gurka.createGurka());
@@ -75,6 +76,7 @@ public class InstrumentMe {
 		instance.printInstanceHelloWorldJFR4(new Gurka[] {Gurka.createGurka(), Gurka.createGurka()});
 		instance.printInstanceHelloWorldJFR5(createGurkList());
 		instance.printInstanceHelloWorldJFR6();
+		instance.printInstanceHelloWorldJFR7();
 	}
 
 	private static void runStatic() throws InterruptedException {
@@ -90,6 +92,7 @@ public class InstrumentMe {
 		printHelloWorldJFR4(new Gurka[] {Gurka.createGurka(), Gurka.createGurka()});
 		printHelloWorldJFR5(createGurkList());
 		printHelloWorldJFR6();
+		printHelloWorldJFR7();
 	}
 
 	private static Collection<Gurka> createGurkList() {
@@ -161,6 +164,15 @@ public class InstrumentMe {
 		return returnval;
 	}
 
+	public static void printHelloWorldJFR7() throws InterruptedException {
+		try {
+			System.out.println("#SJFR7. Hello World!"); //$NON-NLS-1$
+			Thread.sleep(1000);
+		} catch (Exception e) {
+			// intentionally empty
+		}
+	}
+
 	public void printInstanceHelloWorld1() throws InterruptedException {
 		System.out.println("#I1. Hello World!"); //$NON-NLS-1$
 		Thread.sleep(1000);
@@ -220,5 +232,14 @@ public class InstrumentMe {
 		System.out.println(String.format("#IJFR6. retval:%1.3f", returnval)); //$NON-NLS-1$
 		Thread.sleep(1000);
 		return returnval;
+	}
+
+	public void printInstanceHelloWorldJFR7() throws InterruptedException {
+		try {
+			System.out.println("#IJFR7. Hello World!"); //$NON-NLS-1$
+			Thread.sleep(1000);
+		} catch (Exception e) {
+			// intentionally empty
+		}
 	}
 }

--- a/core/org.openjdk.jmc.agent/src/test/resources/org/openjdk/jmc/agent/test/jfrprobes_template.xml
+++ b/core/org.openjdk.jmc.agent/src/test/resources/org/openjdk/jmc/agent/test/jfrprobes_template.xml
@@ -194,5 +194,16 @@
 				</parameter>
 			</method>
 		</event>
+		<event id="demo.jfr.testI7">
+			<name>JFR Hello World Instance Event 7 %TEST_NAME%</name>
+			<description>Defined in the xml file and added by the agent. The original method contains a try-catch clause.</description>
+			<path>demo/jfrhelloworldeventI7</path>
+			<stacktrace>true</stacktrace>
+			<class>org.openjdk.jmc.agent.test.InstrumentMe</class>
+			<method>
+				<name>printInstanceHelloWorldJFR7</name>
+				<descriptor>()V</descriptor>
+			</method>
+		</event>
 	</events>
 </jfragent>


### PR DESCRIPTION
Hello Marcus,

This patch addresses [JMC-6532]. Since JFRMethodAdvisor extends from LocalVariableSorter, which doesn't accept compressed frames, I had to force it to always use expanded frames (ie. `Opcodes.F_NEW`). A test case is included.

Please let me know what you think.

Regards,
(Arvin) Kangcheng Xu

[JMC-6532]: https://bugs.openjdk.java.net/browse/JMC-6532
