### PR TITLE
JMC-5967: Generated code should optionally capture any thrown exceptions and rethrow

### DIFF
--- a/core/org.openjdk.jmc.agent/src/main/java/org/openjdk/jmc/agent/jfr/JFRTransformDescriptor.java
+++ b/core/org.openjdk.jmc.agent/src/main/java/org/openjdk/jmc/agent/jfr/JFRTransformDescriptor.java
@@ -48,6 +48,7 @@ public class JFRTransformDescriptor extends TransformDescriptor {
 	private final static String ATTRIBUTE_JFR_EVENT_DESCRIPTION = "description"; //$NON-NLS-1$
 	private final static String ATTRIBUTE_JFR_EVENT_PATH = "path"; //$NON-NLS-1$
 	private final static String ATTRIBUTE_STACK_TRACE = "stacktrace"; //$NON-NLS-1$
+	private final static String ATTRIBUTE_RETHROW = "rethrow"; //$NON-NLS-1$
 
 	private final String classPrefix;
 	private final String eventDescription;
@@ -55,6 +56,7 @@ public class JFRTransformDescriptor extends TransformDescriptor {
 	private final String eventName;
 	private final String eventPath;
 	private final boolean recordStackTrace;
+	private final boolean useRethrow;
 	private final boolean allowToString;
 	private final boolean allowConverter;
 	private final List<Parameter> parameters;
@@ -68,6 +70,7 @@ public class JFRTransformDescriptor extends TransformDescriptor {
 		eventPath = initializeEventPath();
 		eventDescription = initializeEventDescription();
 		recordStackTrace = getBoolean(ATTRIBUTE_STACK_TRACE, true);
+		useRethrow = getBoolean(ATTRIBUTE_RETHROW, false);
 		allowToString = getBoolean(ATTRIBUTE_ALLOW_TO_STRING, false);
 		allowConverter = getBoolean(ATTRIBUTE_ALLOW_CONVERTER, false);
 		this.parameters = parameters;
@@ -95,6 +98,10 @@ public class JFRTransformDescriptor extends TransformDescriptor {
 
 	public boolean isRecordStackTrace() {
 		return recordStackTrace;
+	}
+
+	public boolean isUseRethrow() {
+		return useRethrow;
 	}
 
 	public boolean isAllowToString() {

--- a/core/org.openjdk.jmc.agent/src/main/java/org/openjdk/jmc/agent/jfr/impl/JFRMethodAdvisor.java
+++ b/core/org.openjdk.jmc.agent/src/main/java/org/openjdk/jmc/agent/jfr/impl/JFRMethodAdvisor.java
@@ -71,7 +71,7 @@ public class JFRMethodAdvisor extends AdviceAdapter {
 
     @Override
     public void visitCode() {
-        super.visitCode();
+		super.visitCode();
 
 		if (transformDescriptor.isUseRethrow()) {
 			visitLabel(tryBegin);
@@ -91,7 +91,7 @@ public class JFRMethodAdvisor extends AdviceAdapter {
 			visitInsn(ATHROW);
 		}
 
-        super.visitEnd();
+		super.visitEnd();
     }
 
 	@Override

--- a/core/org.openjdk.jmc.agent/src/main/java/org/openjdk/jmc/agent/jfr/impl/JFRMethodAdvisor.java
+++ b/core/org.openjdk.jmc.agent/src/main/java/org/openjdk/jmc/agent/jfr/impl/JFRMethodAdvisor.java
@@ -45,8 +45,9 @@ import org.openjdk.jmc.agent.util.TypeUtils;
  * Code emitter for JFR distributed with pre-JDK 9 releases. Probably works with JRockit too. ;)
  */
 public class JFRMethodAdvisor extends AdviceAdapter {
-	private final JFRTransformDescriptor transformDescriptor;
+	private static final String THROWABLE_BINARY_NAME = "java/lang/Throwable"; //$NON-NLS-1$
 
+	private final JFRTransformDescriptor transformDescriptor;
 	private final Type[] argumentTypesRef;
 	private final Type returnTypeRef;
 	private final Type eventType;
@@ -66,7 +67,7 @@ public class JFRMethodAdvisor extends AdviceAdapter {
 		this.returnTypeRef = Type.getReturnType(desc);
 		this.eventType = Type.getObjectType(transformDescriptor.getEventClassName());
 
-		this.shouldInstrumentThrow = !transformDescriptor.isUseRethrow(); // don't instrument inner throws is rethrow is enabled
+		this.shouldInstrumentThrow = !transformDescriptor.isUseRethrow(); // don't instrument inner throws if rethrow is enabled
 	}
 
     @Override
@@ -82,9 +83,9 @@ public class JFRMethodAdvisor extends AdviceAdapter {
     public void visitEnd() {
 		if (transformDescriptor.isUseRethrow()) {
 			visitLabel(tryEnd);
-			visitTryCatchBlock(tryBegin, tryEnd, tryEnd, "java/lang/Exception");
+			visitTryCatchBlock(tryBegin, tryEnd, tryEnd, THROWABLE_BINARY_NAME);
 
-			visitFrame(Opcodes.F_NEW, 0, null, 1, new Object[] {"java/lang/Exception"});
+			visitFrame(Opcodes.F_NEW, 0, null, 1, new Object[] {THROWABLE_BINARY_NAME});
 
 			// Simply rethrow. Event commits are instrumented by onMethodExit()
 			shouldInstrumentThrow = true;

--- a/core/org.openjdk.jmc.agent/src/main/java/org/openjdk/jmc/agent/jfrnext/impl/JFRNextMethodAdvisor.java
+++ b/core/org.openjdk.jmc.agent/src/main/java/org/openjdk/jmc/agent/jfrnext/impl/JFRNextMethodAdvisor.java
@@ -45,6 +45,8 @@ import org.openjdk.jmc.agent.util.TypeUtils;
  * Code emitter for JFR next, i.e. the version of JFR distributed with JDK 9 and later.
  */
 public class JFRNextMethodAdvisor extends AdviceAdapter {
+	private static final String THROWABLE_BINARY_NAME = "java/lang/Throwable"; //$NON-NLS-1$
+
 	private final JFRTransformDescriptor transformDescriptor;
 	private final Type[] argumentTypesRef;
 	private final Type returnTypeRef;
@@ -65,7 +67,7 @@ public class JFRNextMethodAdvisor extends AdviceAdapter {
 		this.returnTypeRef = Type.getReturnType(desc);
 		this.eventType = Type.getObjectType(transformDescriptor.getEventClassName());
 
-		this.shouldInstrumentThrow = !transformDescriptor.isUseRethrow(); // don't instrument inner throws is rethrow is enabled
+		this.shouldInstrumentThrow = !transformDescriptor.isUseRethrow(); // don't instrument inner throws if rethrow is enabled
 	}
 
 	@Override
@@ -81,9 +83,9 @@ public class JFRNextMethodAdvisor extends AdviceAdapter {
 	public void visitEnd() {
 		if (transformDescriptor.isUseRethrow()) {
 			visitLabel(tryEnd);
-			visitTryCatchBlock(tryBegin, tryEnd, tryEnd, "java/lang/Exception");
+			visitTryCatchBlock(tryBegin, tryEnd, tryEnd, THROWABLE_BINARY_NAME);
 
-			visitFrame(Opcodes.F_NEW, 0, null, 1, new Object[] {"java/lang/Exception"});
+			visitFrame(Opcodes.F_NEW, 0, null, 1, new Object[] {THROWABLE_BINARY_NAME});
 
 			// Simply rethrow. Event commits are instrumented by onMethodExit()
 			shouldInstrumentThrow = true;

--- a/core/org.openjdk.jmc.agent/src/main/java/org/openjdk/jmc/agent/jfrnext/impl/JFRNextMethodAdvisor.java
+++ b/core/org.openjdk.jmc.agent/src/main/java/org/openjdk/jmc/agent/jfrnext/impl/JFRNextMethodAdvisor.java
@@ -32,6 +32,7 @@
  */
 package org.openjdk.jmc.agent.jfrnext.impl;
 
+import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
@@ -50,6 +51,11 @@ public class JFRNextMethodAdvisor extends AdviceAdapter {
 	private final Type eventType;
 	private int eventLocal = -1;
 
+	private Label tryBegin = new Label();
+	private Label tryEnd = new Label();
+
+	private boolean shouldInstrumentThrow;
+
 	protected JFRNextMethodAdvisor(JFRTransformDescriptor transformDescriptor, int api, MethodVisitor mv, int access,
 			String name, String desc) {
 		super(api, mv, access, name, desc);
@@ -58,6 +64,33 @@ public class JFRNextMethodAdvisor extends AdviceAdapter {
 		this.argumentTypesRef = Type.getArgumentTypes(desc);
 		this.returnTypeRef = Type.getReturnType(desc);
 		this.eventType = Type.getObjectType(transformDescriptor.getEventClassName());
+
+		this.shouldInstrumentThrow = !transformDescriptor.isUseRethrow(); // don't instrument inner throws is rethrow is enabled
+	}
+
+	@Override
+	public void visitCode() {
+		super.visitCode();
+
+		if (transformDescriptor.isUseRethrow()) {
+			visitLabel(tryBegin);
+		}
+	}
+
+	@Override
+	public void visitEnd() {
+		if (transformDescriptor.isUseRethrow()) {
+			visitLabel(tryEnd);
+			visitTryCatchBlock(tryBegin, tryEnd, tryEnd, "java/lang/Exception");
+
+			visitFrame(Opcodes.F_NEW, 0, null, 1, new Object[] {"java/lang/Exception"});
+
+			// Simply rethrow. Event commits are instrumented by onMethodExit()
+			shouldInstrumentThrow = true;
+			visitInsn(ATHROW);
+		}
+
+		super.visitEnd();
 	}
 
 	@Override
@@ -96,6 +129,10 @@ public class JFRNextMethodAdvisor extends AdviceAdapter {
 
 	@Override
 	protected void onMethodExit(int opcode) {
+		if (opcode == ATHROW && !shouldInstrumentThrow) {
+			return;
+		}
+
 		if (returnTypeRef.getSort() != Type.VOID && opcode != ATHROW) {
 			Parameter returnParam = TypeUtils.findReturnParam(transformDescriptor.getParameters());
 			if (returnParam != null) {

--- a/core/org.openjdk.jmc.agent/src/test/java/org/openjdk/jmc/agent/test/InstrumentMe.java
+++ b/core/org.openjdk.jmc.agent/src/test/java/org/openjdk/jmc/agent/test/InstrumentMe.java
@@ -77,6 +77,21 @@ public class InstrumentMe {
 		instance.printInstanceHelloWorldJFR5(createGurkList());
 		instance.printInstanceHelloWorldJFR6();
 		instance.printInstanceHelloWorldJFR7();
+		try {
+			instance.printInstanceHelloWorldJFR8();
+		} catch (RuntimeException e) {
+			System.out.println("#IJFR8. Caught a RuntimeException: " + e.getMessage());
+		}
+		try {
+			instance.printInstanceHelloWorldJFR9();
+		} catch (RuntimeException e) {
+			System.out.println("#IJFR9. Caught a RuntimeException: " + e.getMessage());
+		}
+		try {
+			instance.printInstanceHelloWorldJFR10();
+		} catch (RuntimeException e) {
+			System.out.println("#IJFR10. Caught a RuntimeException: " + e.getMessage());
+		}
 	}
 
 	private static void runStatic() throws InterruptedException {
@@ -93,6 +108,21 @@ public class InstrumentMe {
 		printHelloWorldJFR5(createGurkList());
 		printHelloWorldJFR6();
 		printHelloWorldJFR7();
+		try {
+			printHelloWorldJFR8();
+		} catch (RuntimeException e) {
+			System.out.println("#IJFR8. Caught a RuntimeException: " + e.getMessage());
+		}
+		try {
+			printHelloWorldJFR9();
+		} catch (RuntimeException e) {
+			System.out.println("#IJFR9. Caught a RuntimeException: " + e.getMessage());
+		}
+		try {
+			printHelloWorldJFR10();
+		} catch (RuntimeException e) {
+			System.out.println("#IJFR10. Caught a RuntimeException: " + e.getMessage());
+		}
 	}
 
 	private static Collection<Gurka> createGurkList() {
@@ -173,6 +203,30 @@ public class InstrumentMe {
 		}
 	}
 
+	public static void printHelloWorldJFR8() throws InterruptedException {
+		System.out.println("#IJFR8. About to throw a RuntimeException"); //$NON-NLS-1$
+		Thread.sleep(1000);
+		(new ArrayList<>()).get(1);
+	}
+
+	public static void printHelloWorldJFR9() throws InterruptedException {
+		System.out.println("#IJFR9. About to throw a RuntimeException"); //$NON-NLS-1$
+		Thread.sleep(1000);
+		(new ArrayList<>()).get(1);
+	}
+
+	public static void printHelloWorldJFR10() throws InterruptedException {
+		System.out.println("#IJFR10. About to throw a RuntimeException"); //$NON-NLS-1$
+		Thread.sleep(1000);
+
+		try {
+			(new ArrayList<>()).get(1);
+		} catch (RuntimeException e) {
+			System.out.println("#IJFR10. Caught a RuntimeException: " + e.getMessage()); //$NON-NLS-1$
+			throw e;
+		}
+	}
+
 	public void printInstanceHelloWorld1() throws InterruptedException {
 		System.out.println("#I1. Hello World!"); //$NON-NLS-1$
 		Thread.sleep(1000);
@@ -240,6 +294,30 @@ public class InstrumentMe {
 			Thread.sleep(1000);
 		} catch (Exception e) {
 			// intentionally empty
+		}
+	}
+
+	public void printInstanceHelloWorldJFR8() throws InterruptedException {
+		System.out.println("#IJFR8. About to throw a RuntimeException"); //$NON-NLS-1$
+		Thread.sleep(1000);
+		(new ArrayList<>()).get(1);
+	}
+
+	public void printInstanceHelloWorldJFR9() throws InterruptedException {
+		System.out.println("#IJFR9. About to throw a RuntimeException"); //$NON-NLS-1$
+		Thread.sleep(1000);
+		(new ArrayList<>()).get(1);
+	}
+
+	public void printInstanceHelloWorldJFR10() throws InterruptedException {
+		System.out.println("#IJFR10. About to throw a RuntimeException"); //$NON-NLS-1$
+		Thread.sleep(1000);
+
+		try {
+			(new ArrayList<>()).get(1);
+		} catch (RuntimeException e) {
+			System.out.println("#IJFR10. Caught a RuntimeException: " + e.getMessage()); //$NON-NLS-1$
+			throw e;
 		}
 	}
 }

--- a/core/org.openjdk.jmc.agent/src/test/resources/org/openjdk/jmc/agent/test/jfrprobes_template.xml
+++ b/core/org.openjdk.jmc.agent/src/test/resources/org/openjdk/jmc/agent/test/jfrprobes_template.xml
@@ -205,5 +205,40 @@
 				<descriptor>()V</descriptor>
 			</method>
 		</event>
+		<event id="demo.jfr.testI8">
+			<name>JFR Hello World Instance Event 8 %TEST_NAME%</name>
+			<description>Defined in the xml file and added by the agent. Should record even if an exception is raised.</description>
+			<path>demo/jfrhelloworldeventI8</path>
+			<stacktrace>true</stacktrace>
+			<class>org.openjdk.jmc.agent.test.InstrumentMe</class>
+			<method>
+				<name>printInstanceHelloWorldJFR8</name>
+				<descriptor>()V</descriptor>
+			</method>
+			<rethrow>true</rethrow>
+		</event>
+		<event id="demo.jfr.testI9">
+			<name>JFR Hello World Instance Event 9 %TEST_NAME%</name>
+			<description>Defined in the xml file and added by the agent. Should not record if an exception is raised.</description>
+			<path>demo/jfrhelloworldeventI9</path>
+			<stacktrace>true</stacktrace>
+			<class>org.openjdk.jmc.agent.test.InstrumentMe</class>
+			<method>
+				<name>printInstanceHelloWorldJFR9</name>
+				<descriptor>()V</descriptor>
+			</method>
+		</event>
+		<event id="demo.jfr.testI10">
+			<name>JFR Hello World Instance Event 10 %TEST_NAME%</name>
+			<description>Defined in the xml file and added by the agent. Should record even if an exception is raised, but should not overwrite the existing try-catch clause.</description>
+			<path>demo/jfrhelloworldeventI10</path>
+			<stacktrace>true</stacktrace>
+			<class>org.openjdk.jmc.agent.test.InstrumentMe</class>
+			<method>
+				<name>printInstanceHelloWorldJFR10</name>
+				<descriptor>()V</descriptor>
+			</method>
+			<rethrow>true</rethrow>
+		</event>
 	</events>
 </jfragent>


### PR DESCRIPTION
Hello Marcus,

This patch implements [JMC-5967](https://bugs.openjdk.java.net/browse/JMC-5967). An optional configuration, `rethrow`, is enables the generated code to capture any thrown exceptions, emit the event, and then re-throw. Test cases are included.

Please let me know what you think.

Regards,
(Arvin) Kangcheng Xu