### PR TITLE
Make return value its own element

### DIFF
--- a/core/org.openjdk.jmc.agent/src/main/java/org/openjdk/jmc/agent/ReturnValue.java
+++ b/core/org.openjdk.jmc.agent/src/main/java/org/openjdk/jmc/agent/ReturnValue.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
- * 
+ *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The contents of this file are subject to the terms of either the Universal Permissive License
@@ -10,17 +10,17 @@
  *
  * Redistribution and use in source and binary forms, with or without modification, are permitted
  * provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
  * and the following disclaimer.
- * 
+ *
  * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
  * conditions and the following disclaimer in the documentation and/or other materials provided with
  * the distribution.
- * 
+ *
  * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
  * endorse or promote products derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
  * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
@@ -35,32 +35,19 @@ package org.openjdk.jmc.agent;
 import org.openjdk.jmc.agent.util.TypeUtils;
 
 /**
- * Metadata for a parameter to be logged by the agent.
+ * Metadata for a return value to be logged by the agent.
  */
-public final class Parameter {
-	public static final int INDEX_INVALID = -1;
-
-	private final int index;
+public final class ReturnValue {
 	private final String name;
 	private final String fieldName;
 	private final String description;
 	private final String contentType;
-	private final String relationKey;
-	private final String converterClassName;
 
-	public Parameter(int index, String name, String description, String contentType, String relationKey,
-			String converterClassName) {
-		this.index = index;
+	public ReturnValue(String name, String description, String contentType) {
 		this.name = name;
 		this.description = description;
 		this.contentType = contentType;
-		this.relationKey = relationKey;
-		this.converterClassName = converterClassName;
-		this.fieldName = "field" + TypeUtils.deriveIdentifierPart(name); //$NON-NLS-1$
-	}
-
-	public int getIndex() {
-		return index;
+		this.fieldName = name == null ? null : "field" + TypeUtils.deriveIdentifierPart(name); //$NON-NLS-1$
 	}
 
 	public String getName() {
@@ -75,19 +62,8 @@ public final class Parameter {
 		return contentType;
 	}
 
-	public String getRelationKey() {
-		return relationKey;
-	}
-
 	public String getFieldName() {
 		return fieldName;
 	}
 
-	public boolean isInvalid() {
-		return index == INDEX_INVALID;
-	}
-
-	public String getConverterClassName() {
-		return converterClassName;
-	}
 }

--- a/core/org.openjdk.jmc.agent/src/main/java/org/openjdk/jmc/agent/TransformDescriptor.java
+++ b/core/org.openjdk.jmc.agent/src/main/java/org/openjdk/jmc/agent/TransformDescriptor.java
@@ -105,8 +105,8 @@ public abstract class TransformDescriptor {
 	 * @return the instantiated {@link TransformDescriptor}.
 	 */
 	public static TransformDescriptor create(
-		String id, String internalName, Method method, Map<String, String> values, List<Parameter> parameters) {
-		return new JFRTransformDescriptor(id, internalName, method, values, parameters);
+		String id, String internalName, Method method, Map<String, String> values, List<Parameter> parameters, ReturnValue returnValue) {
+		return new JFRTransformDescriptor(id, internalName, method, values, parameters, returnValue);
 	}
 
 	@Override

--- a/core/org.openjdk.jmc.agent/src/main/java/org/openjdk/jmc/agent/impl/DefaultTransformRegistry.java
+++ b/core/org.openjdk.jmc.agent/src/main/java/org/openjdk/jmc/agent/impl/DefaultTransformRegistry.java
@@ -50,6 +50,7 @@ import javax.xml.stream.XMLStreamReader;
 
 import org.openjdk.jmc.agent.Method;
 import org.openjdk.jmc.agent.Parameter;
+import org.openjdk.jmc.agent.ReturnValue;
 import org.openjdk.jmc.agent.TransformDescriptor;
 import org.openjdk.jmc.agent.TransformRegistry;
 import org.openjdk.jmc.agent.jfr.JFRTransformDescriptor;
@@ -59,6 +60,7 @@ public class DefaultTransformRegistry implements TransformRegistry {
 	private static final String XML_ELEMENT_NAME_EVENT = "event"; //$NON-NLS-1$
 	private static final String XML_ELEMENT_METHOD_NAME = "method"; //$NON-NLS-1$
 	private static final String XML_ELEMENT_PARAMETER_NAME = "parameter"; //$NON-NLS-1$
+	private static final String XML_ELEMENT_RETURN_VALUE_NAME = "returnvalue"; //$NON-NLS-1$
 
 	// Global override section
 	private static final String XML_ELEMENT_CONFIGURATION = "config"; //$NON-NLS-1$
@@ -150,11 +152,12 @@ public class DefaultTransformRegistry implements TransformRegistry {
 		Map<String, String> values = new HashMap<>();
 		List<Parameter> parameters = new LinkedList<>();
 		Method method = null;
+		ReturnValue returnValue = null;
 		while (streamReader.hasNext()) {
 			if (streamReader.isStartElement()) {
 				String name = streamReader.getName().getLocalPart();
 				if (XML_ELEMENT_METHOD_NAME.equals(name)) {
-					method = parseMethod(streamReader, parameters);
+					method = parseMethod(streamReader, parameters, returnValue);
 					continue;
 				}
 				streamReader.next();
@@ -174,7 +177,7 @@ public class DefaultTransformRegistry implements TransformRegistry {
 			streamReader.next();
 		}
 		transfer(globalDefaults, values);
-		return TransformDescriptor.create(id, getInternalName(values.get("class")), method, values, parameters); //$NON-NLS-1$
+		return TransformDescriptor.create(id, getInternalName(values.get("class")), method, values, parameters, returnValue); //$NON-NLS-1$
 	}
 
 	private static void transfer(HashMap<String, String> globalDefaults, Map<String, String> values) {
@@ -256,11 +259,44 @@ public class DefaultTransformRegistry implements TransformRegistry {
 		return new Parameter(index, name, description, contentType, relationKey, converterClassName);
 	}
 
+	private static ReturnValue parseReturnValue(XMLStreamReader streamReader) throws XMLStreamException {
+		streamReader.next();
+		String name = null;
+		String description = null;
+		String contentType = null;
+
+		while (streamReader.hasNext()) {
+			if (streamReader.isStartElement()) {
+				String key = streamReader.getName().getLocalPart();
+				streamReader.next();
+				if (streamReader.hasText()) {
+					String value = streamReader.getText();
+					if (value != null) {
+						value = value.trim();
+					}
+					if ("name".equals(key)) { //$NON-NLS-1$
+						name = value;
+					} else if ("description".equals(key)) { //$NON-NLS-1$
+						description = value;
+					} else if ("contenttype".equals(key)) { //$NON-NLS-1$
+						contentType = value;
+					}
+				}
+			} else if (streamReader.isEndElement()) {
+				if (XML_ELEMENT_RETURN_VALUE_NAME.equals(streamReader.getName().getLocalPart())) {
+					break;
+				}
+			}
+			streamReader.next();
+		}
+		return new ReturnValue(name, description, contentType);
+	}
+
 	private static String getInternalName(String className) {
 		return className.replace('.', '/');
 	}
 
-	private static Method parseMethod(XMLStreamReader streamReader, List<Parameter> parameters)
+	private static Method parseMethod(XMLStreamReader streamReader, List<Parameter> parameters, ReturnValue returnValue)
 			throws XMLStreamException {
 		streamReader.next();
 		String name = null;
@@ -273,6 +309,10 @@ public class DefaultTransformRegistry implements TransformRegistry {
 						String indexAttribute = streamReader.getAttributeValue(0);
 						parameters.add(parseParameter(Integer.parseInt(indexAttribute), streamReader));
 					}
+					continue;
+				}
+				if (XML_ELEMENT_RETURN_VALUE_NAME.equals(key)) {
+					returnValue = parseReturnValue(streamReader);
 					continue;
 				}
 				streamReader.next();

--- a/core/org.openjdk.jmc.agent/src/main/java/org/openjdk/jmc/agent/jfr/JFRTransformDescriptor.java
+++ b/core/org.openjdk.jmc.agent/src/main/java/org/openjdk/jmc/agent/jfr/JFRTransformDescriptor.java
@@ -40,6 +40,7 @@ import java.util.logging.Logger;
 import org.objectweb.asm.Type;
 import org.openjdk.jmc.agent.Method;
 import org.openjdk.jmc.agent.Parameter;
+import org.openjdk.jmc.agent.ReturnValue;
 import org.openjdk.jmc.agent.TransformDescriptor;
 import org.openjdk.jmc.agent.util.TypeUtils;
 
@@ -60,9 +61,10 @@ public class JFRTransformDescriptor extends TransformDescriptor {
 	private final boolean allowToString;
 	private final boolean allowConverter;
 	private final List<Parameter> parameters;
+	private final ReturnValue returnValue;
 
 	public JFRTransformDescriptor(String id, String className, Method method,
-			Map<String, String> transformationAttributes, List<Parameter> parameters) {
+			Map<String, String> transformationAttributes, List<Parameter> parameters, ReturnValue returnValue) {
 		super(id, className, method, transformationAttributes);
 		classPrefix = initializeClassPrefix();
 		eventName = initializeEventName();
@@ -74,6 +76,7 @@ public class JFRTransformDescriptor extends TransformDescriptor {
 		allowToString = getBoolean(ATTRIBUTE_ALLOW_TO_STRING, false);
 		allowConverter = getBoolean(ATTRIBUTE_ALLOW_CONVERTER, false);
 		this.parameters = parameters;
+		this.returnValue = returnValue;
 	}
 
 	public String getEventClassName() {
@@ -173,6 +176,10 @@ public class JFRTransformDescriptor extends TransformDescriptor {
 
 	public List<Parameter> getParameters() {
 		return parameters;
+	}
+
+	public ReturnValue getReturnValue() {
+		return returnValue;
 	}
 
 	public boolean isAllowedFieldType(Type type) {

--- a/core/org.openjdk.jmc.agent/src/main/java/org/openjdk/jmc/agent/jfr/impl/JFREventClassGenerator.java
+++ b/core/org.openjdk.jmc.agent/src/main/java/org/openjdk/jmc/agent/jfr/impl/JFREventClassGenerator.java
@@ -42,6 +42,7 @@ import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 import org.openjdk.jmc.agent.Parameter;
+import org.openjdk.jmc.agent.ReturnValue;
 import org.openjdk.jmc.agent.jfr.JFRTransformDescriptor;
 import org.openjdk.jmc.agent.util.TypeUtils;
 
@@ -81,11 +82,10 @@ public class JFREventClassGenerator {
 	private static void generateAttributeFields(ClassWriter cw, JFRTransformDescriptor td) {
 		Type[] args = Type.getArgumentTypes(td.getMethod().getSignature());
 		for (Parameter param : td.getParameters()) {
-			if (param.isReturn()) {
-				createField(cw, td, param, Type.getReturnType(td.getMethod().getSignature()));
-			} else {
-				createField(cw, td, param, args[param.getIndex()]);
-			}
+			createField(cw, td, param, args[param.getIndex()]);
+		}
+		if (td.getReturnValue() != null) {
+			createField(cw, td, td.getReturnValue(), Type.getReturnType(td.getMethod().getSignature()));
 		}
 	}
 
@@ -112,6 +112,31 @@ public class JFREventClassGenerator {
 		}
 		if (param.getRelationKey() != null) {
 			av.visit("relationKey", param.getRelationKey()); //$NON-NLS-1$
+		}
+		av.visitEnd();
+		fv.visitEnd();
+	}
+
+	private static void createField(ClassWriter cw, JFRTransformDescriptor td, ReturnValue returnValue, Type type) {
+		if (!td.isAllowedFieldType(type)) {
+			Logger.getLogger(JFREventClassGenerator.class.getName())
+					.warning("Skipped generating field in event class for return value " + returnValue + " and type " + type //$NON-NLS-1$ //$NON-NLS-2$
+							+ " because of configuration settings!"); //$NON-NLS-1$
+			return;
+		}
+
+		String fieldType = getFieldType(type);
+
+		FieldVisitor fv = cw.visitField(Opcodes.ACC_PUBLIC, returnValue.getFieldName(), fieldType, null, null);
+		AnnotationVisitor av = fv.visitAnnotation("Lcom/oracle/jrockit/jfr/ValueDefinition;", true); //$NON-NLS-1$
+		if (returnValue.getName() != null) {
+			av.visit("name", returnValue.getName()); //$NON-NLS-1$
+		}
+		if (returnValue.getDescription() != null) {
+			av.visit("description", returnValue.getDescription()); //$NON-NLS-1$
+		}
+		if (returnValue.getContentType() != null) {
+			av.visitEnum("contentType", "Lcom/oracle/jrockit/jfr/ContentType;", returnValue.getContentType()); //$NON-NLS-1$ //$NON-NLS-2$
 		}
 		av.visitEnd();
 		fv.visitEnd();

--- a/core/org.openjdk.jmc.agent/src/main/java/org/openjdk/jmc/agent/jfrnext/impl/JFRNextEventClassGenerator.java
+++ b/core/org.openjdk.jmc.agent/src/main/java/org/openjdk/jmc/agent/jfrnext/impl/JFRNextEventClassGenerator.java
@@ -43,6 +43,7 @@ import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 import org.openjdk.jmc.agent.Agent;
 import org.openjdk.jmc.agent.Parameter;
+import org.openjdk.jmc.agent.ReturnValue;
 import org.openjdk.jmc.agent.jfr.JFRTransformDescriptor;
 import org.openjdk.jmc.agent.util.TypeUtils;
 
@@ -67,11 +68,10 @@ public class JFRNextEventClassGenerator {
 	private static void generateAttributeFields(ClassWriter cw, JFRTransformDescriptor td) {
 		Type[] args = Type.getArgumentTypes(td.getMethod().getSignature());
 		for (Parameter param : td.getParameters()) {
-			if (param.isReturn()) {
-				createField(cw, td, param, Type.getReturnType(td.getMethod().getSignature()));
-			} else {
-				createField(cw, td, param, args[param.getIndex()]);
-			}
+			createField(cw, td, param, args[param.getIndex()]);
+		}
+		if (td.getReturnValue() != null) {
+			createField(cw, td, td.getReturnValue(), Type.getReturnType(td.getMethod().getSignature()));
 		}
 	}
 
@@ -101,6 +101,45 @@ public class JFRNextEventClassGenerator {
 		// We support the old JDK 7 style content types transparently.
 		// We also support user defined content types and a single string value annotation parameter to the annotation.
 		String contentTypeAnnotation = getContentTypeAnnotation(param.getContentType());
+		if (contentTypeAnnotation != null) {
+			String[] contentTypeAnnotationInfo = contentTypeAnnotation.split(";");
+			av = fv.visitAnnotation(contentTypeAnnotationInfo[0] + ";", true);
+			if (contentTypeAnnotationInfo.length > 1) {
+				av.visit("value", contentTypeAnnotationInfo[1]);
+			}
+			av.visitEnd();
+		}
+
+		// FIXME: RelKey
+		fv.visitEnd();
+	}
+
+	private static void createField(ClassWriter cw, JFRTransformDescriptor td, ReturnValue returnValue, Type type) {
+		if (!td.isAllowedFieldType(type)) {
+			Logger.getLogger(JFRNextEventClassGenerator.class.getName())
+					.warning("Skipped generating field in event class for return value " + returnValue + " and type " + type //$NON-NLS-1$ //$NON-NLS-2$
+							+ " because of configuration settings!"); //$NON-NLS-1$
+			return;
+		}
+
+		String fieldType = getFieldType(type);
+
+		FieldVisitor fv = cw.visitField(Opcodes.ACC_PROTECTED, returnValue.getFieldName(), fieldType, null, null);
+
+		// Name
+		AnnotationVisitor av = fv.visitAnnotation("Ljdk/jfr/Label;", true);
+		av.visit("value", returnValue.getName());
+		av.visitEnd();
+
+		// Description
+		av = fv.visitAnnotation("Ljdk/jfr/Description;", true);
+		av.visit("value", returnValue.getDescription());
+		av.visitEnd();
+
+		// "ContentType"
+		// We support the old JDK 7 style content types transparently.
+		// We also support user defined content types and a single string value annotation parameter to the annotation.
+		String contentTypeAnnotation = getContentTypeAnnotation(returnValue.getContentType());
 		if (contentTypeAnnotation != null) {
 			String[] contentTypeAnnotationInfo = contentTypeAnnotation.split(";");
 			av = fv.visitAnnotation(contentTypeAnnotationInfo[0] + ";", true);

--- a/core/org.openjdk.jmc.agent/src/main/java/org/openjdk/jmc/agent/jfrnext/impl/JFRNextMethodAdvisor.java
+++ b/core/org.openjdk.jmc.agent/src/main/java/org/openjdk/jmc/agent/jfrnext/impl/JFRNextMethodAdvisor.java
@@ -38,6 +38,7 @@ import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.commons.AdviceAdapter;
 import org.openjdk.jmc.agent.Parameter;
+import org.openjdk.jmc.agent.ReturnValue;
 import org.openjdk.jmc.agent.jfr.JFRTransformDescriptor;
 import org.openjdk.jmc.agent.util.TypeUtils;
 
@@ -106,13 +107,11 @@ public class JFRNextMethodAdvisor extends AdviceAdapter {
 		mv.visitInsn(DUP);
 		mv.visitMethodInsn(INVOKESPECIAL, transformDescriptor.getEventClassName(), "<init>", "()V", false); //$NON-NLS-1$ //$NON-NLS-2$
 		for (Parameter param : transformDescriptor.getParameters()) {
-			if (!param.isReturn()) {
-				Type argumentType = argumentTypesRef[param.getIndex()];
-				if (transformDescriptor.isAllowedFieldType(argumentType)) {
-					mv.visitInsn(DUP);
-					loadArg(param.getIndex());
-					writeParameter(param, argumentType);
-				}
+			Type argumentType = argumentTypesRef[param.getIndex()];
+			if (transformDescriptor.isAllowedFieldType(argumentType)) {
+				mv.visitInsn(DUP);
+				loadArg(param.getIndex());
+				writeParameter(param, argumentType);
 			}
 		}
 
@@ -122,11 +121,19 @@ public class JFRNextMethodAdvisor extends AdviceAdapter {
 	}
 
 	private void writeParameter(Parameter param, Type type) {
-		if (TypeUtils.shouldStringify(param, type)) {
-			TypeUtils.stringify(mv, param, type);
+		if (TypeUtils.shouldStringify(type)) {
+			TypeUtils.stringify(mv);
 			type = TypeUtils.STRING_TYPE;
 		}
 		putField(Type.getObjectType(transformDescriptor.getEventClassName()), param.getFieldName(), type);
+	}
+
+	private void writeReturnValue(ReturnValue returnValue, Type type) {
+		if (TypeUtils.shouldStringify(type)) {
+			TypeUtils.stringify(mv);
+			type = TypeUtils.STRING_TYPE;
+		}
+		putField(Type.getObjectType(transformDescriptor.getEventClassName()), returnValue.getFieldName(), type);
 	}
 
 	@Override
@@ -136,15 +143,15 @@ public class JFRNextMethodAdvisor extends AdviceAdapter {
 		}
 
 		if (returnTypeRef.getSort() != Type.VOID && opcode != ATHROW) {
-			Parameter returnParam = TypeUtils.findReturnParam(transformDescriptor.getParameters());
-			if (returnParam != null) {
-				emitSettingReturnParam(opcode, returnParam);
+			ReturnValue returnValue = transformDescriptor.getReturnValue();
+			if (returnValue != null) {
+				emitSettingReturnParam(opcode, returnValue);
 			}
 		}
 		commitEvent();
 	}
 
-	private void emitSettingReturnParam(int opcode, Parameter returnParam) {
+	private void emitSettingReturnParam(int opcode, ReturnValue returnValue) {
 		if (returnTypeRef.getSize() == 1) {
 			dup();
 			mv.visitVarInsn(ALOAD, eventLocal);
@@ -155,7 +162,7 @@ public class JFRNextMethodAdvisor extends AdviceAdapter {
 			dupX2();
 			pop();
 		}
-		writeParameter(returnParam, returnTypeRef);
+		writeReturnValue(returnValue, returnTypeRef);
 	}
 
 	private void commitEvent() {

--- a/core/org.openjdk.jmc.agent/src/main/java/org/openjdk/jmc/agent/util/TypeUtils.java
+++ b/core/org.openjdk.jmc.agent/src/main/java/org/openjdk/jmc/agent/util/TypeUtils.java
@@ -37,7 +37,6 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.security.ProtectionDomain;
-import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -45,7 +44,6 @@ import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 import org.openjdk.jmc.agent.Agent;
-import org.openjdk.jmc.agent.Parameter;
 import org.openjdk.jmc.agent.jfr.impl.JFRUtils;
 
 /**
@@ -214,25 +212,16 @@ public final class TypeUtils {
 		return fqcn;
 	}
 
-	public static void stringify(MethodVisitor mv, Parameter param, Type argumentType) {
+	public static void stringify(MethodVisitor mv) {
 		mv.visitMethodInsn(Opcodes.INVOKESTATIC, INAME, "toString", //$NON-NLS-1$
 				"(Ljava/lang/Object;)Ljava/lang/String;", false); //$NON-NLS-1$
 	}
 
-	public static boolean shouldStringify(Parameter param, Type argumentType) {
+	public static boolean shouldStringify(Type argumentType) {
 		if (argumentType.getSort() == Type.ARRAY || argumentType.getSort() == Type.OBJECT) {
 			return !argumentType.getInternalName().equals(STRING_INTERNAL_NAME);
 		}
 		return false;
-	}
-
-	public static Parameter findReturnParam(List<Parameter> parameters) {
-		for (Parameter p : parameters) {
-			if (p.isReturn()) {
-				return p;
-			}
-		}
-		return null;
 	}
 
 	/**

--- a/core/org.openjdk.jmc.agent/src/test/resources/org/openjdk/jmc/agent/test/jfrprobes_template.xml
+++ b/core/org.openjdk.jmc.agent/src/test/resources/org/openjdk/jmc/agent/test/jfrprobes_template.xml
@@ -78,11 +78,10 @@
 					<description>The second parameter</description>
 					<contenttype>Bytes</contenttype>	
 				</parameter>
-				<parameter index="-1">
-					<name>Return Value</name>
+				<returnvalue>
 					<description>The return value</description>
 					<contenttype>None</contenttype>	
-				</parameter>				
+				</returnvalue>
 			</method>
 			<!-- location {ENTRY, EXIT, WRAP}-->
 			<location>WRAP</location>
@@ -119,11 +118,10 @@
 					<description>The second parameter</description>
 					<contenttype>Bytes</contenttype>	
 				</parameter>
-				<parameter index="-1">
-					<name>Return Value</name>
+				<returnvalue>
 					<description>The return value</description>
 					<contenttype>None</contenttype>	
-				</parameter>				
+				</returnvalue>
 			</method>
 		</event>
 		<event id="demo.jfr.testI3">
@@ -187,11 +185,10 @@
 				<name>printInstanceHelloWorldJFR6</name>						
 				<descriptor>()D</descriptor>
 				<!-- Note that this will only work if we allow toString -->
-				<parameter index="-1">
-					<name>Return Value</name>
+				<returnvalue>
 					<description>A value between 0 and 100 (double)</description>
 					<contenttype>Percentage</contenttype>	
-				</parameter>
+				</returnvalue>
 			</method>
 		</event>
 		<event id="demo.jfr.testI7">


### PR DESCRIPTION
This patch addresses [JMC-6617](https://bugs.openjdk.java.net/browse/JMC-6617): Better probe format for return values.  

Currently method return values are described using a parameter element with an index of -1.  This patch makes a designated returnValue element that can be used for return values.
